### PR TITLE
modificacion de fifo_mod.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+obj-m += fifo_mod.o
+
+KDIR := /lib/modules/$(shell uname -r)/build
+PWD  := $(shell pwd)
+
+default:
+	$(MAKE) -C $(KDIR) M=$(PWD) modules
+
+clean:
+	$(MAKE) -C $(KDIR) M=$(PWD) clean

--- a/fifo_mod.c
+++ b/fifo_mod.c
@@ -1,4 +1,3 @@
-
 #include <linux/init.h>      // Macros __init y __exit
 #include <linux/module.h>    // Funciones básicas de módulo
 #include <linux/kernel.h>    // printk()
@@ -15,26 +14,26 @@ static char *mensaje = "Hola desde el kernel!\n";
 static struct file *fifo_file;
 
 static int __init fifo_mod_init(void) {
-    mm_segment_t old_fs;
+
     loff_t pos = 0;
 
     printk(KERN_INFO "fifo_mod: Cargando módulo...\n");
 
     // Permitir acceso a espacio de usuario
-    old_fs = get_fs();
-    set_fs(KERNEL_DS);
+
+
 
     fifo_file = filp_open("/tmp/mi_fifo", O_WRONLY | O_CREAT, 0666);
     if (IS_ERR(fifo_file)) {
         printk(KERN_ALERT "fifo_mod: No se pudo abrir el FIFO\n");
-        set_fs(old_fs);
+
         return PTR_ERR(fifo_file);
     }
 
     kernel_write(fifo_file, mensaje, strlen(mensaje), &pos);
     filp_close(fifo_file, NULL);
 
-    set_fs(old_fs);
+
     printk(KERN_INFO "fifo_mod: Mensaje escrito en el FIFO\n");
     return 0;
 }

--- a/fifo_mod.c
+++ b/fifo_mod.c
@@ -1,0 +1,44 @@
+#include <linux/init.h>      // Macros __init y __exit
+#include <linux/module.h>    // Funciones básicas de módulo
+#include <linux/kernel.h>    // printk()
+#include <linux/fs.h>        // struct file, filp_open
+#include <linux/uaccess.h>   // copy_to_user
+#include <linux/slab.h>      // kmalloc y kfree
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Mariana");
+MODULE_DESCRIPTION("Módulo simple que escribe en un FIFO");
+MODULE_VERSION("0.1");
+
+static char *mensaje = "Hola desde el kernel!\n";
+static struct file *fifo_file;
+
+static int __init fifo_mod_init(void) {
+    
+    loff_t pos = 0;
+
+    printk(KERN_INFO "fifo_mod: Cargando módulo...\n");
+
+    
+
+    fifo_file = filp_open("/tmp/mi_fifo", O_WRONLY | O_CREAT, 0666);
+    if (IS_ERR(fifo_file)) {
+        printk(KERN_ALERT "fifo_mod: No se pudo abrir el FIFO\n");
+        
+        return PTR_ERR(fifo_file);
+    }
+
+    kernel_write(fifo_file, mensaje, strlen(mensaje), &pos);
+    filp_close(fifo_file, NULL);
+
+    
+    printk(KERN_INFO "fifo_mod: Mensaje escrito en el FIFO\n");
+    return 0;
+}
+
+static void __exit fifo_mod_exit(void) {
+    printk(KERN_INFO "fifo_mod: Saliendo del módulo...\n");
+}
+
+module_init(fifo_mod_init);
+module_exit(fifo_mod_exit);

--- a/fifo_mod.c
+++ b/fifo_mod.c
@@ -1,3 +1,4 @@
+
 #include <linux/init.h>      // Macros __init y __exit
 #include <linux/module.h>    // Funciones básicas de módulo
 #include <linux/kernel.h>    // printk()
@@ -14,24 +15,26 @@ static char *mensaje = "Hola desde el kernel!\n";
 static struct file *fifo_file;
 
 static int __init fifo_mod_init(void) {
-    
+    mm_segment_t old_fs;
     loff_t pos = 0;
 
     printk(KERN_INFO "fifo_mod: Cargando módulo...\n");
 
-    
+    // Permitir acceso a espacio de usuario
+    old_fs = get_fs();
+    set_fs(KERNEL_DS);
 
     fifo_file = filp_open("/tmp/mi_fifo", O_WRONLY | O_CREAT, 0666);
     if (IS_ERR(fifo_file)) {
         printk(KERN_ALERT "fifo_mod: No se pudo abrir el FIFO\n");
-        
+        set_fs(old_fs);
         return PTR_ERR(fifo_file);
     }
 
     kernel_write(fifo_file, mensaje, strlen(mensaje), &pos);
     filp_close(fifo_file, NULL);
 
-    
+    set_fs(old_fs);
     printk(KERN_INFO "fifo_mod: Mensaje escrito en el FIFO\n");
     return 0;
 }

--- a/kernel_module.mk
+++ b/kernel_module.mk
@@ -1,0 +1,16 @@
+# Nombre del módulo
+obj-m := fifo_mod.o
+
+# Ruta al kernel actual
+KDIR := /lib/modules/$(shell uname -r)/build
+
+# Directorio actual
+PWD := $(shell pwd)
+
+# Compilación
+all:
+	$(MAKE) -C $(KDIR) M=$(PWD) modules
+
+# Limpieza de archivos generados
+clean:
+	$(MAKE) -C $(KDIR) M=$(PWD) clean


### PR DESCRIPTION
Codigo del Modulo
Linea 17:
Se eliminó mm_segment_t old_fs:ya que funciones como "mm_segment_t" han sido eliminadas por temas de seguridad en kernels actuales
Tambien se eliminaron la  liena: set_fs(old_fs);