### PR TITLE
Versión inicial del fifo_mod.c

### DIFF
--- a/fifo_mod.c
+++ b/fifo_mod.c
@@ -1,0 +1,46 @@
+#include <linux/init.h>      // Macros __init y __exit
+#include <linux/module.h>    // Funciones básicas de módulo
+#include <linux/kernel.h>    // printk()
+#include <linux/fs.h>        // struct file, filp_open
+#include <linux/uaccess.h>   // copy_to_user
+#include <linux/slab.h>      // kmalloc y kfree
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Mariana");
+MODULE_DESCRIPTION("Módulo simple que escribe en un FIFO");
+MODULE_VERSION("0.1");
+
+static char *mensaje = "Hola desde el kernel!\n";
+static struct file *fifo_file;
+
+static int __init fifo_mod_init(void) {
+    mm_segment_t old_fs;
+    loff_t pos = 0;
+
+    printk(KERN_INFO "fifo_mod: Cargando módulo...\n");
+
+    // Permitir acceso a espacio de usuario
+    old_fs = get_fs();
+    set_fs(KERNEL_DS);
+
+    fifo_file = filp_open("/tmp/mi_fifo", O_WRONLY | O_CREAT, 0666);
+    if (IS_ERR(fifo_file)) {
+        printk(KERN_ALERT "fifo_mod: No se pudo abrir el FIFO\n");
+        set_fs(old_fs);
+        return PTR_ERR(fifo_file);
+    }
+
+    kernel_write(fifo_file, mensaje, strlen(mensaje), &pos);
+    filp_close(fifo_file, NULL);
+
+    set_fs(old_fs);
+    printk(KERN_INFO "fifo_mod: Mensaje escrito en el FIFO\n");
+    return 0;
+}
+
+static void __exit fifo_mod_exit(void) {
+    printk(KERN_INFO "fifo_mod: Saliendo del módulo...\n");
+}
+
+module_init(fifo_mod_init);
+module_exit(fifo_mod_exit);


### PR DESCRIPTION
Este commit agrega una versión básica del módulo de kernel `fifo_mod` que escribe el mensaje "Hola desde el kernel!" en un FIFO ubicado en `/tmp/mi_fifo`. El módulo realiza las siguientes operaciones:
- Usa `filp_open` y `kernel_write` para abrir y escribir en el FIFO.
- Configura el segmento de acceso (`set_fs`) para permitir escritura desde el kernel al espacio de usuario.
- Cierra el archivo FIFO correctamente tras la escritura.
- Imprime mensajes en el log del kernel (`dmesg`) para indicar su carga y descarga.